### PR TITLE
Fixed static "Records per page"-Text for RecordsPerPage component

### DIFF
--- a/resources/views/default/components/records_per_page.php
+++ b/resources/views/default/components/records_per_page.php
@@ -1,6 +1,9 @@
-<span>Records per page</span>
 <?php
 /** @var Nayjest\Grids\Components\RecordsPerPage $component */
+?>
+<span><?php echo $component->getName(); ?></span>
+
+<?php
 echo \Form::select(
     $component->getInputName(),
     $component->getVariants(),

--- a/src/Components/RecordsPerPage.php
+++ b/src/Components/RecordsPerPage.php
@@ -14,7 +14,7 @@ use Nayjest\Grids\Components\Base\RenderableComponent;
 class RecordsPerPage extends RenderableComponent
 {
 
-    protected $name = 'records_per_page';
+    protected $name = 'Records per page';
 
     protected $variants = [
         50,


### PR DESCRIPTION
Hi Nayjest!

As I wanted to change the default "Records per page"-label while using the RecordsPerPage component I noticed that when using (new RecordsPerPage)->setName('...') the Grid did not reflect the change of name. After some stepping through your - I have to add: nicely structured - code I found the reason to be that the viewtemplate had a static ""-element in it which did not reference $component->getName().

This is my purposed patch which I am currently using in my application without problems (using Laravel v5.1.26 and PHP 5.6.15-1+deb.sury.org~trusty+1 on homestead.

I would kindly appreciate if you would consider adding my patch, as I think others might also be affected by this behavioural inconsistency. 

Kind regards,

Christopher