### PR TITLE
Fix path to publish views

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -41,7 +41,7 @@ class ServiceProvider extends BaseServiceProvider
             $this->loadViewsFrom($views_path, 'grids');
             $this->loadTranslationsFrom($pkg_path . '/resources/lang', 'grids');
             $this->publishes([
-                $views_path => base_path('resources/views/nayjest/grids')
+                $views_path => resource_path('views/vendor/grids')
             ]);
         }
         if (!class_exists('Grids')) {


### PR DESCRIPTION
Currently, running `artisan vendor:publish` installs grids views into `resources/views/nayjest/grids`.  They actually need to be added to `resources/views/vendor/grids` for Laravel to pick them up.