### PR TITLE
Readme: illuminate/html should be replaced in command too

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ php composer.phar require nayjest/grids
 ```
 For Laravel 5
 ```bash    
-php composer.phar require nayjest/grids illuminate/html
+php composer.phar require nayjest/grids laravelcollective/html
 ```
 
 ##### Step 2: Laravel Setup


### PR DESCRIPTION
Slight inconstency I found
Seems to have been missed in this commit: 1032639726f2599e21a4b13e8d49c09a49c43fd9