### PR TITLE
Add LIKE_R operator & improve like wildcard detection

### DIFF
--- a/src/DbalDataProvider.php
+++ b/src/DbalDataProvider.php
@@ -158,24 +158,27 @@ class DbalDataProvider extends DataProvider
 
     public function filter($fieldName, $operator, $value)
     {
-         switch ($operator) {
+        switch ($operator) {
+            case 'like_r':
+                $operator = 'like';
+                break;
             case "eq":
                 $operator = '=';
                 break;
             case "n_eq":
-                $operator = '<>';    
+                $operator = '<>';
                 break;
             case "gt":
-                $operator = '>';    
-                 break;
+                $operator = '>';
+                break;
             case "lt":
-                $operator = '<';    
+                $operator = '<';
                 break;
             case "ls_e":
-                $operator = '<=';    
+                $operator = '<=';
                 break;
             case "gt_e":
-                $operator = '>=';    
+                $operator = '>=';
                 break;
         }
         $this->src->andWhere("$fieldName $operator :$fieldName");

--- a/src/EloquentDataProvider.php
+++ b/src/EloquentDataProvider.php
@@ -121,23 +121,26 @@ class EloquentDataProvider extends DataProvider
     public function filter($fieldName, $operator, $value)
     {
         switch ($operator) {
+            case 'like_r':
+                $operator = 'like';
+                break;
             case "eq":
                 $operator = '=';
                 break;
             case "n_eq":
-                $operator = '<>';    
+                $operator = '<>';
                 break;
             case "gt":
-                $operator = '>';    
-                 break;
+                $operator = '>';
+                break;
             case "lt":
-                $operator = '<';    
+                $operator = '<';
                 break;
             case "ls_e":
-                $operator = '<=';    
+                $operator = '<=';
                 break;
             case "gt_e":
-                $operator = '>=';    
+                $operator = '>=';
                 break;
         }
         $this->src->where($fieldName, $operator, $value);

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -111,12 +111,23 @@ class Filter
             $func($value, $this->grid->getConfig()->getDataProvider());
             return;
         }
-        if (strpos($value, '%') === false) {
-            $operator = $this->config->getOperator();
-            if ($operator === FilterConfig::OPERATOR_LIKE) {
-                $value = "%$value%";
-            } else if ($operator === FilterConfig::OPERATOR_LIKE_R) {
-                $value .= '%';
+        $operator = $this->config->getOperator();
+        if ($operator === FilterConfig::OPERATOR_LIKE || $operator === FilterConfig::OPERATOR_LIKE_R) {
+            // Search for non-escaped wildcards
+            $found = false;
+            for ($i = 0; $i < mb_strlen($value); $i++) {
+                if (in_array(mb_substr($value, $i, 1), ['%', '_']) && $i > 0 && mb_substr($value, $i - 1, 1) != '\\') {
+                    $found = true;
+                    break;
+                }
+            }
+            // If none are found, insert wildcards to improve user experience
+            if (!$found) {
+                if ($operator === FilterConfig::OPERATOR_LIKE) {
+                    $value = "%$value%";
+                } else if ($operator === FilterConfig::OPERATOR_LIKE_R) {
+                    $value .= '%';
+                }
             }
         }
         $this->grid->getConfig()->getDataProvider()->filter(

--- a/src/Filter.php
+++ b/src/Filter.php
@@ -111,9 +111,13 @@ class Filter
             $func($value, $this->grid->getConfig()->getDataProvider());
             return;
         }
-        $isLike = $this->config->getOperator() === FilterConfig::OPERATOR_LIKE;
-        if ($isLike && strpos($value, '%') === false) {
-            $value = "%$value%";
+        if (strpos($value, '%') === false) {
+            $operator = $this->config->getOperator();
+            if ($operator === FilterConfig::OPERATOR_LIKE) {
+                $value = "%$value%";
+            } else if ($operator === FilterConfig::OPERATOR_LIKE_R) {
+                $value .= '%';
+            }
         }
         $this->grid->getConfig()->getDataProvider()->filter(
             $this->config->getName(),

--- a/src/FilterConfig.php
+++ b/src/FilterConfig.php
@@ -4,6 +4,7 @@ namespace Nayjest\Grids;
 class FilterConfig
 {
     const OPERATOR_LIKE = 'like';
+    const OPERATOR_LIKE_R = 'like_r';
     const OPERATOR_EQ = 'eq';
     const OPERATOR_NOT_EQ = 'n_eq';
     const OPERATOR_GT = 'gt';


### PR DESCRIPTION
By default the LIKE operator wraps the value in % which causes horrible performance on large tables, since indexes cannot be used (at least MySQL won't)
The LIKE_R operator only appends a % instead of wrapping the value, if there is no wildcard present.

I also improved the wildcard detection, since the single character (_) wildcard might be used or be escaped
