### PR TITLE
Cast records_per_page as int

### DIFF
--- a/src/Components/RecordsPerPage.php
+++ b/src/Components/RecordsPerPage.php
@@ -73,7 +73,7 @@ class RecordsPerPage extends RenderableComponent
         if ($from_input === null) {
             return $this->grid->getConfig()->getPageSize();
         } else {
-            return $from_input;
+            return (int) $from_input;
         }
     }
 


### PR DESCRIPTION
Generates an error if a string (from the request) is passed into `Illuminate\Database\Query\Builder::limit()` with MongoDB driver.