### PR TITLE
Allow dotted field names in column hider

### DIFF
--- a/resources/views/default/components/columns_hider.php
+++ b/resources/views/default/components/columns_hider.php
@@ -123,7 +123,7 @@
         }
 
         ColumnHider.prototype.getColumnElements = function (name) {
-            return $('.column-' + name);
+            return $('[class="column-' + name + '"]');
         };
 
         ColumnHider.prototype.saveValues = function() {
@@ -139,7 +139,7 @@
             if(name === 'all') {
                 $.each(this.getValues(), function(i){
                     me.getValues()[i] = value;
-                    $('input[name='+i+']').prop('checked', value);
+                    $('input[name="'+i+'"]').prop('checked', value);
                     me.updateColumnVisibility(i, value);
                 });
             } else {


### PR DESCRIPTION
This allows dotted field names to be used in the column hider.  Since the table columns are hidden by applying a class based on the field name, they must be selected by using an attribute selector e.g. `$('[class="a.b.c"]')` instead of `$('.a.b.c`)` which gets misinterpreted for obvious reasons.  The other approach would be to escape/replace the dots when generating the class names, but this seemed easier.