### PR TITLE
Handle a non-existent field in an array

### DIFF
--- a/src/ObjectDataRow.php
+++ b/src/ObjectDataRow.php
@@ -18,7 +18,7 @@ class ObjectDataRow extends DataRow
             $parts = explode('.', $fieldName);
             $res = $this->src;
             foreach ($parts as $part) {
-                $res = is_object($res) ? $res->{$part} : $res[$part];
+                $res = data_get($res, $part);
                 if ($res === null) {
                     return $res;
                 }


### PR DESCRIPTION
This was giving me an error, since I had several records for which a particular field was not defined.  Since I use a schema-less DB (MongoDB), this field doesn't even exist with a null value.  `data_get` performs an `array_key_exists` check before attempting to use `$part` as an index for the `$res` array.

This entire method could actually be replaced with data_get for simplicity, since this is what Laravel uses internally to retrieve values in dot notation.
```php
protected function extractCellValue($fieldName)
{
    try {
        return data_get($this->src, $fieldName);
    } catch (Exception $e) {
        throw new RuntimeException(
            "Can't read '$fieldName' property from DataRow",
            0,
            $e
        );
    }
}
```