### PR TITLE
Added ability to use SQL "table.field" notation as FieldConfig name

### DIFF
--- a/src/ObjectDataRow.php
+++ b/src/ObjectDataRow.php
@@ -16,14 +16,26 @@ class ObjectDataRow extends DataRow
 
         if (strpos($fieldName, '.') !== false) {
             $parts = explode('.', $fieldName);
+            $parts = array_reverse($parts);
             $res = $this->src;
-            foreach ($parts as $part) {
-                $res = data_get($res, $part);
-                if ($res === null) {
-                    return $res;
+            try {
+                foreach ($parts as $part) {
+                    $res = is_object($res) ? $res->{$part} : $res[$part];
+                    if ($res !== null) {
+                        return $res;
+                    }
                 }
+            } catch(Exception $e) {
+                throw new RuntimeException(
+                    "Can't read '$fieldName' as '$part' property from DataRow",
+                    0,
+                    $e
+                );
             }
-            return $res;
+            throw new RuntimeException(
+                "Can't read '$fieldName' property from DataRow",
+                0
+            );
         } else {
             try {
                 return $this->src->{$fieldName};


### PR DESCRIPTION
Example: If i use field name "u.id" now first will be tried to read "id" property and then "u". If something went wrong, now exceptions are thrown.