### PR TITLE
The ability to specify a label for a column header without using a fi…

### DIFF
--- a/resources/views/default/components/filters_row.php
+++ b/resources/views/default/components/filters_row.php
@@ -11,6 +11,9 @@
                     class="column-<?= $column->getName() ?>"
                     <?= $column->isHidden()?'style="display:none"':'' ?>
                     >
+                    <div class="column-label">
+                        <?= $column->getLabel() ?>
+                    </div>
                     <?php if ($column->hasFilters()): ?>
                         <?php foreach($column->getFilters() as $filter): ?>
                             <?= $grid->getFiltering()->render($filter) ?>


### PR DESCRIPTION
Hi.
Now the only way to set a label for the column headers (in the default template) is to use a filter. Please consider the possibility of doing this for the default template by using the setLabel function for FieldConfig. it looks logical. Thank you