### PR TITLE
Fix Laravel 5.8 compatibility (Event::fire is depricated)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "venespana/grids",
+    "name": "kaily6/grids",
     "description": "Grids for Laravel 4 & Laravel 5 frameworks",
     "keywords": [
         "grid",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nayjest/grids",
+    "name": "venespana/grids",
     "description": "Grids for Laravel 4 & Laravel 5 frameworks",
     "keywords": [
         "grid",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "kaily6/grids",
+    "name": "nayjest/grids",
     "description": "Grids for Laravel 4 & Laravel 5 frameworks",
     "keywords": [
         "grid",

--- a/src/DbalDataProvider.php
+++ b/src/DbalDataProvider.php
@@ -122,7 +122,7 @@ class DbalDataProvider extends DataProvider
             $item = $this->iterator->current();
             $this->iterator->next();
             $row = new ObjectDataRow($item, $this->getRowId());
-            Event::fire(self::EVENT_FETCH_ROW, [$row, $this]);
+            Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
             return $row;
         } else {
             return null;

--- a/src/DbalDataProvider.php
+++ b/src/DbalDataProvider.php
@@ -123,7 +123,7 @@ class DbalDataProvider extends DataProvider
             $this->iterator->next();
             $row = new ObjectDataRow($item, $this->getRowId());
 
-            if (version_compare(Application::VERSION, '5.8', '>')) {
+            if (version_compare(Application::VERSION, '5.8', '>=')) {
                 Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
             } else {
                 Event::fire(self::EVENT_FETCH_ROW, [$row, $this]);

--- a/src/DbalDataProvider.php
+++ b/src/DbalDataProvider.php
@@ -4,6 +4,7 @@ namespace Nayjest\Grids;
 use DB;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Event;
+use App;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 
@@ -96,7 +97,7 @@ class DbalDataProvider extends DataProvider
      */
     public function getPaginationFactory()
     {
-        return \App::make('paginator');
+        return App::make('paginator');
     }
 
     protected function getIterator()
@@ -122,7 +123,13 @@ class DbalDataProvider extends DataProvider
             $item = $this->iterator->current();
             $this->iterator->next();
             $row = new ObjectDataRow($item, $this->getRowId());
-            Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
+
+            if (preg_match('/5.8.*/', App::VERSION())) {
+                Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
+            } else {
+                Event::fire(self::EVENT_FETCH_ROW, [$row, $this]);
+            }
+
             return $row;
         } else {
             return null;

--- a/src/DbalDataProvider.php
+++ b/src/DbalDataProvider.php
@@ -4,7 +4,6 @@ namespace Nayjest\Grids;
 use DB;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Event;
-use App;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Collection;
 
@@ -97,7 +96,7 @@ class DbalDataProvider extends DataProvider
      */
     public function getPaginationFactory()
     {
-        return App::make('paginator');
+        return \App::make('paginator');
     }
 
     protected function getIterator()
@@ -124,7 +123,7 @@ class DbalDataProvider extends DataProvider
             $this->iterator->next();
             $row = new ObjectDataRow($item, $this->getRowId());
 
-            if (preg_match('/5.8.*/', App::VERSION())) {
+            if (version_compare(Application::VERSION, '5.8', '>')) {
                 Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
             } else {
                 Event::fire(self::EVENT_FETCH_ROW, [$row, $this]);

--- a/src/EloquentDataProvider.php
+++ b/src/EloquentDataProvider.php
@@ -91,7 +91,7 @@ class EloquentDataProvider extends DataProvider
             $item = $this->iterator->current();
             $this->iterator->next();
             $row = new EloquentDataRow($item, $this->getRowId());
-            Event::fire(self::EVENT_FETCH_ROW, [$row, $this]);
+            Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
             return $row;
         } else {
             return null;

--- a/src/EloquentDataProvider.php
+++ b/src/EloquentDataProvider.php
@@ -91,7 +91,13 @@ class EloquentDataProvider extends DataProvider
             $item = $this->iterator->current();
             $this->iterator->next();
             $row = new EloquentDataRow($item, $this->getRowId());
-            Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
+
+            if (preg_match('/5.8.*/', App::VERSION())) {
+                Event::dispatch(self::EVENT_PREPARE, $this);
+            } else {
+                Event::fire(self::EVENT_PREPARE, $this);
+            }
+
             return $row;
         } else {
             return null;

--- a/src/EloquentDataProvider.php
+++ b/src/EloquentDataProvider.php
@@ -92,7 +92,7 @@ class EloquentDataProvider extends DataProvider
             $this->iterator->next();
             $row = new EloquentDataRow($item, $this->getRowId());
 
-            if (version_compare(Application::VERSION, '5.8', '>')) {
+            if (version_compare(Application::VERSION, '5.8', '>=')) {
                 Event::dispatch(self::EVENT_PREPARE, $this);
             } else {
                 Event::fire(self::EVENT_PREPARE, $this);

--- a/src/EloquentDataProvider.php
+++ b/src/EloquentDataProvider.php
@@ -92,7 +92,7 @@ class EloquentDataProvider extends DataProvider
             $this->iterator->next();
             $row = new EloquentDataRow($item, $this->getRowId());
 
-            if (preg_match('/5.8.*/', App::VERSION())) {
+            if (version_compare(Application::VERSION, '5.8', '>')) {
                 Event::dispatch(self::EVENT_PREPARE, $this);
             } else {
                 Event::fire(self::EVENT_PREPARE, $this);

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -38,7 +38,7 @@ class Grid
         }
 
         $this->initializeComponents();
-        Event::fire(self::EVENT_CREATE, $this);
+        Event::dispatch(self::EVENT_CREATE, $this);
     }
 
     /**
@@ -67,7 +67,7 @@ class Grid
         $this->getFiltering()->apply();
         $this->prepareColumns();
         $this->getSorter()->apply();
-        Event::fire(self::EVENT_PREPARE, $this);
+        Event::dispatch(self::EVENT_PREPARE, $this);
         $this->prepared = true;
     }
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -38,7 +38,12 @@ class Grid
         }
 
         $this->initializeComponents();
-        Event::dispatch(self::EVENT_CREATE, $this);
+
+        if (preg_match('/5.8.*/', App::VERSION())) {
+            Event::dispatch(self::EVENT_CREATE, $this);
+        } else {
+            Event::fire(self::EVENT_CREATE, $this);
+        }
     }
 
     /**
@@ -67,7 +72,13 @@ class Grid
         $this->getFiltering()->apply();
         $this->prepareColumns();
         $this->getSorter()->apply();
-        Event::dispatch(self::EVENT_PREPARE, $this);
+
+        if (preg_match('/5.8.*/', App::VERSION())) {
+            Event::dispatch(self::EVENT_PREPARE, $this);
+        } else {
+            Event::fire(self::EVENT_PREPARE, $this);
+        }
+
         $this->prepared = true;
     }
 

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -6,6 +6,7 @@ use Cache;
 use Nayjest\Grids\Components\TFoot;
 use Nayjest\Grids\Components\THead;
 use View;
+use Illuminate\Foundation\Application;
 
 class Grid
 {
@@ -39,7 +40,7 @@ class Grid
 
         $this->initializeComponents();
 
-        if (preg_match('/5.8.*/', App::VERSION())) {
+        if (version_compare(Application::VERSION, '5.8', '>')) {
             Event::dispatch(self::EVENT_CREATE, $this);
         } else {
             Event::fire(self::EVENT_CREATE, $this);
@@ -73,7 +74,7 @@ class Grid
         $this->prepareColumns();
         $this->getSorter()->apply();
 
-        if (preg_match('/5.8.*/', App::VERSION())) {
+        if (version_compare(Application::VERSION, '5.8', '>')) {
             Event::dispatch(self::EVENT_PREPARE, $this);
         } else {
             Event::fire(self::EVENT_PREPARE, $this);

--- a/src/Grid.php
+++ b/src/Grid.php
@@ -40,7 +40,7 @@ class Grid
 
         $this->initializeComponents();
 
-        if (version_compare(Application::VERSION, '5.8', '>')) {
+        if (version_compare(Application::VERSION, '5.8', '>=')) {
             Event::dispatch(self::EVENT_CREATE, $this);
         } else {
             Event::fire(self::EVENT_CREATE, $this);
@@ -74,7 +74,7 @@ class Grid
         $this->prepareColumns();
         $this->getSorter()->apply();
 
-        if (version_compare(Application::VERSION, '5.8', '>')) {
+        if (version_compare(Application::VERSION, '5.8', '>=')) {
             Event::dispatch(self::EVENT_PREPARE, $this);
         } else {
             Event::fire(self::EVENT_PREPARE, $this);


### PR DESCRIPTION
I have updated Event::fire use method.
Now Laravel version is being checked and Event::dispatch done for Laravel 5.8

Related to #206 

@Nayjest Please take a look =) 