### PR TITLE
Fix bug in EloquentDataProvider.php

### DIFF
--- a/src/EloquentDataProvider.php
+++ b/src/EloquentDataProvider.php
@@ -93,9 +93,9 @@ class EloquentDataProvider extends DataProvider
             $row = new EloquentDataRow($item, $this->getRowId());
 
             if (version_compare(Application::VERSION, '5.8', '>=')) {
-                Event::dispatch(self::EVENT_PREPARE, $this);
+                Event::dispatch(self::EVENT_FETCH_ROW, $this);
             } else {
-                Event::fire(self::EVENT_PREPARE, $this);
+                Event::fire(self::EVENT_FETCH_ROW, $this);
             }
 
             return $row;


### PR DESCRIPTION
Bug : reference to EVENT_PREPARE that does not exist.
I think this bug was introduced by commit : 109f0c4828ccf6cced5e55a445f7a3c514eb0856