### PR TITLE
Fix bug caused the "Class 'Input' not found" error.

### DIFF
--- a/src/Components/Laravel5/Pager.php
+++ b/src/Components/Laravel5/Pager.php
@@ -2,7 +2,7 @@
 namespace Nayjest\Grids\Components\Laravel5;
 
 use Illuminate\Pagination\Paginator;
-use Input;
+use Request;
 use Nayjest\Grids\Components\Base\RenderableComponent;
 use Nayjest\Grids\Grid;
 
@@ -24,7 +24,7 @@ class Pager extends RenderableComponent
     protected function setupPaginationForReading()
     {
         Paginator::currentPageResolver(function () {
-            return Input::get("$this->input_key.page", 1);
+            return Request::get("$this->input_key.page", 1);
         });
     }
 

--- a/src/GridInputProcessor.php
+++ b/src/GridInputProcessor.php
@@ -1,7 +1,7 @@
 <?php
 namespace Nayjest\Grids;
 
-use Input;
+use Request;
 use Request;
 use Form;
 
@@ -37,7 +37,7 @@ class GridInputProcessor
 
     protected function loadInput()
     {
-        $this->input = Input::get($this->getKey(), []);
+        $this->input = Request::get($this->getKey(), []);
     }
 
     /**


### PR DESCRIPTION
Illuminate\Support\Facades\Input is deprecated in Laravel 6 and we have to use Illuminate\Support\Facades\Request instead.
If you use older versions of Laravel you have to add the following line to the app configuration.
'Request' => Illuminate\Support\Facades\Input::class,

Closes #200