### PR TITLE
Fix issue #200 - address deprecated Input facade for Laravel version 6 and up, with 4.2 fallback

### DIFF
--- a/src/Components/Laravel5/Pager.php
+++ b/src/Components/Laravel5/Pager.php
@@ -2,7 +2,7 @@
 namespace Nayjest\Grids\Components\Laravel5;
 
 use Illuminate\Pagination\Paginator;
-use Input;
+use Illuminate\Support\Facades\App;
 use Nayjest\Grids\Components\Base\RenderableComponent;
 use Nayjest\Grids\Grid;
 
@@ -24,7 +24,11 @@ class Pager extends RenderableComponent
     protected function setupPaginationForReading()
     {
         Paginator::currentPageResolver(function () {
-            return Input::get("$this->input_key.page", 1);
+          if (version_compare(App::version(), '6.0', '>=')) {
+            return \Illuminate\Support\Facades\Request::input("$this->input_key.page", 1);
+          } else {
+            return \Illuminate\Support\Facades\Input::get("$this->input_key.page", 1);
+          }
         });
     }
 

--- a/src/GridInputProcessor.php
+++ b/src/GridInputProcessor.php
@@ -1,6 +1,7 @@
 <?php
 namespace Nayjest\Grids;
 
+use Illuminate\Support\Facades\App;
 use Input;
 use Request;
 use Form;
@@ -37,7 +38,11 @@ class GridInputProcessor
 
     protected function loadInput()
     {
-        $this->input = Input::get($this->getKey(), []);
+      if (version_compare(App::version(), '6.0', '>=')) {
+        $this->input = \Illuminate\Support\Facades\Request::input($this->getKey(), []);
+      } else {
+        $this->input = \Illuminate\Support\Facades\Input::get($this->getKey(), []);
+      }
     }
 
     /**


### PR DESCRIPTION
I need this to be fixed. It is in use in a client project that we have just updated to L6 and the error is breaking all our admin backend. 

https://github.com/Nayjest/Grids/issues/200
https://github.com/Nayjest/Grids/pull/214#issuecomment-605437093