### PR TITLE
Maatwebsite/Excel v3 support through new component

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Laravel 4.X, Laravel 5.X and Laravel 6 are supported.
 
 * Laravel 4.X / 5.X / 6.X
 * laravelcollective/html package if you use Laravel5.X
-* php 5.4+
+* php 5.5+
 
 ## Installation
 
@@ -433,7 +433,7 @@ If you discover any security related issues, please email mail@vitaliy.in instea
 
 ## License
 
-© 2014&mdash;2019 Vitalii Stepanenko
+© 2014&mdash;2022 Vitalii Stepanenko
 
 Licensed under the MIT License. 
 

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=5.5.0",
         "illuminate/support": ">=4.2",
         "nayjest/builder": "~2"
+    },
+    "require-dev": {
+        "laravel/framework": "^5.5.0"
     },
     "suggest": {
         "laravelcollective/html": "Required to work with Laravel 5.X",

--- a/src/Components/ExcelExport.php
+++ b/src/Components/ExcelExport.php
@@ -209,6 +209,11 @@ class ExcelExport extends RenderableComponent
     {
         /** @var Excel $excel */
         $excel = app('excel');
+
+        if (!method_exists($excel, 'create')) {
+            throw new \RuntimeException('U are most likely using Maatwebsite/Excel v3 or newer. Use PhpSpreadsheetExport component instead');
+        }
+
         $excel
             ->create($this->getFileName(), $this->getOnFileCreate())
             ->export($this->getExtension());

--- a/src/Components/PhpSpreadsheetExport.php
+++ b/src/Components/PhpSpreadsheetExport.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Nayjest\Grids\Components;
+
+
+use Generator;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Maatwebsite\Excel\Concerns\FromGenerator;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Events\BeforeSheet;
+use Maatwebsite\Excel\Excel;
+use Maatwebsite\Excel\Exporter;
+use Nayjest\Grids\Grid;
+
+
+/**
+ * When using Maatwebsite/Excel v3 (or newer) which uses PhpSpreadsheet in place of PhpExcel
+ * use this export component in place of ExcelExport component. It provides same funcionality
+ * but uses newer API
+ * 
+ * Be careful this file is compatible with php version 7 and above. Don't try to use this
+ * component in projects using older PHP versions.
+ * 
+ * @author: Janusz Paszynski
+ * @package Nayjest\Grids\Components
+ */
+class PhpSpreadsheetExport extends ExcelExport implements FromGenerator, WithHeadings, WithEvents
+{
+    /** @var Exporter */
+    protected $exporter;
+
+    public function __construct()
+    {
+        if(!interface_exists('Maatwebsite\Excel\Exporter')) {
+            throw new \RuntimeException('It seems there is no Maatwebsite v3 installed. Install it or use ExcelExport component');
+        }
+    }
+
+    public function initialize(Grid $grid)
+    {
+        parent::initialize($grid);
+        $this->exporter = \app(Exporter::class);
+    }
+
+    /** @inheritDoc */
+    protected function renderExcel()
+    {
+        $response = $this->exporter->download($this, sprintf('%s.%s', $this->getFileName(), $this->getExtension()), Excel::XLSX);
+        throw new HttpResponseException($response);
+    }
+
+    /** @inheritDoc */
+    public function generator(): Generator
+    {
+        $columnsConfig = $this->grid->getConfig()->getColumns();
+        $provider = $this->grid->getConfig()->getDataProvider();
+        $this->resetPagination($provider);
+        $provider->reset();
+        while($row = $provider->getRow()) {
+            $output = [];
+            foreach($columnsConfig as $column) {
+                if ($this->isColumnExported($column)) {
+                    $output[] = $this->escapeString($column->getValue($row));
+                }
+            }
+            yield $output;
+        }
+    }
+
+	/**
+	 *
+	 * @return array
+	 */
+	function headings(): array
+    {
+        return $this->getHeaderRow();
+	}
+
+	/**
+	 *
+	 * @return array
+	 */
+	function registerEvents(): array
+    {
+        return [
+            BeforeSheet::class => function(BeforeSheet $event) {
+                $sheetTitle = $this->getSheetName();
+                if ($sheetTitle) {
+                    $event->sheet->setTitle($sheetTitle);
+                }
+            }
+        ];
+	}
+
+}


### PR DESCRIPTION
Created new PhpSpreadsheetExport component as compatible with Maatwebsite/Excel v3 and newer. Needs PHP 7 to run (but should run on PHP 5.5 if new component is not loaded), It adresses #211 and #224 issues.

Tried it to be as much similar with rest of package as possible.

There is exception used for delivering response from within grid rendering process. Couldn't find better cleaner way to do it without requiring users to change way they deliver grid to view.

Tested it with:
- laravel v5.5.43
- PHP v7.4.30
- maatwebsite/excel v3.1.25