### PR TITLE
Doctrine DBAL 3 support

### DIFF
--- a/src/DbalDataProvider.php
+++ b/src/DbalDataProvider.php
@@ -57,14 +57,17 @@ class DbalDataProvider extends DataProvider
                 ->setMaxResults($this->page_size);
             if ($this->isExecUsingLaravel()) {
                 $res = DB::select($query, $query->getParameters());
+            } elseif ($this->isDbal3()) {
+                // for DBAL 3 use new executeQuery() method instead of deprecated execute()
+                $res = $query->executeQuery()->fetchAllAssociative();
             } else {
+                // for DBAL 2
                 $res = $query->execute()->fetchAll(\PDO::FETCH_OBJ);
             }
             $this->collection = Collection::make($res);
         }
         return $this->collection;
     }
-
 
     public function getPaginator()
     {
@@ -121,7 +124,11 @@ class DbalDataProvider extends DataProvider
             $this->index++;
             $item = $this->iterator->current();
             $this->iterator->next();
-            $row = new ObjectDataRow($item, $this->getRowId());
+            if (is_array($item)) {
+                $row = new ArrayDataRow($item, $this->getRowId());
+            } else {
+                $row = new ObjectDataRow($item, $this->getRowId());
+            }
 
             if (version_compare(Application::VERSION, '5.8', '>=')) {
                 Event::dispatch(self::EVENT_FETCH_ROW, [$row, $this]);
@@ -211,6 +218,16 @@ class DbalDataProvider extends DataProvider
     public function setExecUsingLaravel($execUsingLaravel)
     {
         $this->exec_using_laravel = $execUsingLaravel;
+    }
+
+    /**
+     * Checks if Doctrine DBAL 3 is used
+     *
+     * @return bool
+     */
+    private function isDbal3()
+    {
+        return class_exists('\Doctrine\DBAL\Result');
     }
 
 }


### PR DESCRIPTION
- simple Doctrine/DBAL 3 presence detection
- Doctrine/DBAL 3 specific fetching
- Object/Array data row depending on item type used

Doctrine DBAL 3 is installed with Laravel 11 and PHP 8 due to symfony/http-foundation conflict and own laravel/framework requirement. Grid is therefore causing errors when used with doctrine data provider in Laravel 11 application.